### PR TITLE
Adds accessor method prefixes

### DIFF
--- a/lib/bitmasker/bitmask_attributes.rb
+++ b/lib/bitmasker/bitmask_attributes.rb
@@ -10,10 +10,15 @@ module Bitmasker
     class_attribute :model_class
     class_attribute :field_name
 
-
-    def self.make(model_class, field_name, bitmask_attributes, defaults = {})
+    def self.make(model_class, field_name, bitmask_attributes, attribute_prefix='', defaults = {})
       klass = Class.new(self) do
         define_attribute_methods bitmask_attributes.keys
+
+        if attribute_prefix.present?
+          bitmask_attributes.keys.each do |key|
+            alias_attribute "#{attribute_prefix}#{key}", key
+          end
+        end
       end
 
       klass.model_class = model_class
@@ -52,8 +57,17 @@ module Bitmasker
       Bitmask.new(bitmask_attributes, was).get attribute
     end
 
+    def from_array(array)
+      bitmask.set_array(Array(array).map(&:to_s).map(&:presence).compact)
+      write
+    end
+
     def to_a
       bitmask.to_a
+    end
+
+    def <<(attr)
+      send(:attribute=, attr.to_s, true)
     end
 
     # Methods for the model

--- a/lib/bitmasker/bitmask_attributes.rb
+++ b/lib/bitmasker/bitmask_attributes.rb
@@ -43,22 +43,6 @@ module Bitmasker
       @bitmask = Bitmask.new(bitmask_attributes, read || defaults)
     end
 
-    def &(other)
-      @bitmask.data & other.bitmask.data
-    end
-
-    def |(other)
-      @bitmask.data | other.bitmask.data
-    end
-
-    def ^(other)
-      @bitmask.data ^ other.bitmask.data
-    end
-
-    def ~(other)
-      @bitmask.data ~ other.bitmask.data
-    end
-
     def attribute(attribute)
       bitmask.get attribute
     end

--- a/lib/bitmasker/bitmask_attributes.rb
+++ b/lib/bitmasker/bitmask_attributes.rb
@@ -43,6 +43,22 @@ module Bitmasker
       @bitmask = Bitmask.new(bitmask_attributes, read || defaults)
     end
 
+    def &(other)
+      @bitmask.data & other.bitmask.data
+    end
+
+    def |(other)
+      @bitmask.data | other.bitmask.data
+    end
+
+    def ^(other)
+      @bitmask.data ^ other.bitmask.data
+    end
+
+    def ~(other)
+      @bitmask.data ~ other.bitmask.data
+    end
+
     def attribute(attribute)
       bitmask.get attribute
     end

--- a/lib/bitmasker/bitmask_attributes.rb
+++ b/lib/bitmasker/bitmask_attributes.rb
@@ -10,19 +10,19 @@ module Bitmasker
     class_attribute :model_class
     class_attribute :field_name
 
-    def self.make(model_class, field_name, bitmask_attributes, attribute_prefix='', defaults = {})
+    def self.make(model_class, field_name, attrs, prefix = "", defaults = {})
       klass = Class.new(self) do
-        define_attribute_methods bitmask_attributes.keys
+        define_attribute_methods attrs.keys
 
-        if attribute_prefix.present?
-          bitmask_attributes.keys.each do |key|
-            alias_attribute "#{attribute_prefix}#{key}", key
+        if prefix.present?
+          attrs.keys.each do |key|
+            alias_attribute "#{prefix}#{key}", key
           end
         end
       end
 
       klass.model_class = model_class
-      klass.bitmask_attributes = bitmask_attributes.stringify_keys
+      klass.bitmask_attributes = attrs.stringify_keys
       klass.defaults = defaults.stringify_keys
       klass.field_name = field_name
 

--- a/lib/bitmasker/bitmask_scope.rb
+++ b/lib/bitmasker/bitmask_scope.rb
@@ -31,20 +31,26 @@ module Bitmasker
       Bitmask.new(bitmask_attributes, 0)
     end
 
+    def field_name_for_bit_query(field_name)
+      @field_name_for_bit_query ||= {}
+      @field_name_for_bit_query[field_name] ||=
+        model_class.connection.quote_table_name_for_assignment(model_class.table_name, field_name)
+    end
+
     # REVIEW: This (the unused _ attribute) tells me I have the design wrong
     def with_attribute(_, *attributes)
       # TODO: Test lots of databases
-      bitmask_query attributes, "#{field_name} & :mask = :mask"
+      bitmask_query attributes, "#{field_name_for_bit_query(field_name)} & :mask = :mask"
     end
 
     def with_any_attribute(_, *attributes)
       # TODO: Test lots of databases
-      bitmask_query attributes, "#{field_name} & :mask <> 0"
+      bitmask_query attributes, "#{field_name_for_bit_query(field_name)} & :mask <> 0"
     end
 
     def without_attribute(_, *attributes)
       # TODO: Test lots of databases
-      bitmask_query attributes, "#{field_name} & :mask = 0 OR #{field_name} IS NULL"
+      bitmask_query attributes, "#{field_name_for_bit_query(field_name)} & :mask = 0 OR #{field_name_for_bit_query(field_name)} IS NULL"
     end
 
     private

--- a/lib/bitmasker/generator.rb
+++ b/lib/bitmasker/generator.rb
@@ -1,6 +1,6 @@
 module Bitmasker
   class Generator
-    def initialize(mask_name, model, attribute_prefix='')
+    def initialize(mask_name, model, attribute_prefix = "")
       @bitmask_attributes = {}
       @bitmask_defaults = {}
 
@@ -36,7 +36,13 @@ module Bitmasker
     end
 
     def generate
-      klass = BitmaskAttributes.make(@model, @field_name, @bitmask_attributes, @attribute_prefix, @bitmask_defaults)
+      klass = BitmaskAttributes.make(
+        @model,
+        @field_name,
+        @bitmask_attributes,
+        @attribute_prefix,
+        @bitmask_defaults
+      )
       scope_klass = BitmaskScope.make(@model, @field_name, @mask_name, @bitmask_attributes)
 
       @model.send :define_method, @mask_name do

--- a/lib/bitmasker/generator.rb
+++ b/lib/bitmasker/generator.rb
@@ -50,6 +50,22 @@ module Bitmasker
       end
 
       mask_name = @mask_name
+      field_name = @field_name
+
+      @model.singleton_class.send :define_method, @field_name do |*names|
+        names = names.each_with_object({}) { |name, hsh| hsh[name.to_s] = true }
+        Bitmask.new(klass.bitmask_attributes, names)
+      end
+
+      @model.send :define_method, :"has_#{@mask_name}?" do |*names|
+        other = self.class.send(field_name, *names).to_i
+        (send(field_name).to_i & other.to_i) == other.to_i
+      end
+
+      @model.send :define_method, :"has_any_#{@mask_name}?" do |*names|
+        other = self.class.send(field_name, *names).to_i
+        (send(field_name).to_i & other.to_i) > 0
+      end
 
       @model.send :define_method, :"#{@mask_name}=" do |attrs|
         send(mask_name).from_array(attrs)

--- a/lib/bitmasker/generator.rb
+++ b/lib/bitmasker/generator.rb
@@ -26,9 +26,9 @@ module Bitmasker
     # makes the config dsl more consistent
     alias_method :field_name, :field_name=
 
-    def attribute(name, mask, default = false)
+    def attribute(name, mask, default = nil)
       @bitmask_attributes[name] = mask
-      @bitmask_defaults[name] = default
+      @bitmask_defaults[name] = default unless default.nil?
     end
 
     def accessible

--- a/lib/bitmasker/model.rb
+++ b/lib/bitmasker/model.rb
@@ -1,6 +1,6 @@
 module Bitmasker
   module Model
-    def has_bitmask_attributes(name, attribute_prefix='')
+    def has_bitmask_attributes(name, attribute_prefix = "")
       raise ArgumentError, "You must pass has_bitmask_attributes a block and define attributes." unless block_given?
       config = Generator.new(name, self, attribute_prefix)
       yield config

--- a/lib/bitmasker/model.rb
+++ b/lib/bitmasker/model.rb
@@ -1,8 +1,8 @@
 module Bitmasker
   module Model
-    def has_bitmask_attributes(name)
+    def has_bitmask_attributes(name, attribute_prefix='')
       raise ArgumentError, "You must pass has_bitmask_attributes a block and define attributes." unless block_given?
-      config = Generator.new(name, self)
+      config = Generator.new(name, self, attribute_prefix)
       yield config
       config.generate
     end

--- a/lib/bitmasker/version.rb
+++ b/lib/bitmasker/version.rb
@@ -1,3 +1,3 @@
 module Bitmasker
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/test/bitmasker/bitmask_attributes_test.rb
+++ b/test/bitmasker/bitmask_attributes_test.rb
@@ -2,6 +2,30 @@ require 'test_helper'
 
 class Bitmasker::BitmaskAttributesTest < MiniTest::Unit::TestCase
 
+  LiveModel = Class.new do
+    def self.value_to_boolean(value)
+      !!value
+    end
+
+    def initialize(*args)
+      @attrs = {}
+      @old_attrs = {}
+    end
+
+    def [](attr)
+      @attrs.fetch(attr, 0)
+    end
+
+    def []=(name, value)
+      @old_attrs[name] = @attrs[name] unless @old_attrs.present?
+      @attrs[name] = value
+    end
+
+    def attribute_was(attr)
+      @old_attrs.fetch(attr, 0)
+    end
+  end
+
   MockModel = Class.new do
     def self.value_to_boolean(value)
       !!value
@@ -63,4 +87,36 @@ class Bitmasker::BitmaskAttributesTest < MiniTest::Unit::TestCase
     model_instance.expects(:[]).with('email_mask').returns(2)
     assert_equal ['send_monthly_newsletter'], subject.to_a
   end
+
+  def test_prefix_accessors
+    @klass = Bitmasker::BitmaskAttributes.make(
+      LiveModel, 'role_mask',
+      {
+        manager: 0b0001,
+        admin: 0b0010,
+      },
+      'has_role_'
+    )
+
+    subject = @klass.new(LiveModel.new)
+
+    assert_equal false, subject.has_role_manager
+    assert_equal false, subject.has_role_manager?
+
+    subject.has_role_manager = true
+
+    assert_equal true, subject.has_role_manager
+    assert_equal true, subject.has_role_manager?
+    assert_equal false, subject.has_role_manager_was
+
+    assert_equal false, subject.has_role_admin
+    assert_equal false, subject.has_role_admin?
+
+    subject.has_role_admin = true
+
+    assert_equal true, subject.has_role_admin
+    assert_equal true, subject.has_role_admin?
+    assert_equal false, subject.has_role_admin_was
+  end
 end
+

--- a/test/bitmasker/bitmask_attributes_test.rb
+++ b/test/bitmasker/bitmask_attributes_test.rb
@@ -7,7 +7,7 @@ class Bitmasker::BitmaskAttributesTest < MiniTest::Unit::TestCase
       !!value
     end
 
-    def initialize(*args)
+    def initialize(*)
       @attrs = {}
       @old_attrs = {}
     end
@@ -90,12 +90,12 @@ class Bitmasker::BitmaskAttributesTest < MiniTest::Unit::TestCase
 
   def test_prefix_accessors
     @klass = Bitmasker::BitmaskAttributes.make(
-      LiveModel, 'role_mask',
+      LiveModel, "role_mask",
       {
         manager: 0b0001,
         admin: 0b0010,
       },
-      'has_role_'
+      "has_role_"
     )
 
     subject = @klass.new(LiveModel.new)
@@ -119,4 +119,3 @@ class Bitmasker::BitmaskAttributesTest < MiniTest::Unit::TestCase
     assert_equal false, subject.has_role_admin_was
   end
 end
-

--- a/test/bitmasker/bitmask_scope_test.rb
+++ b/test/bitmasker/bitmask_scope_test.rb
@@ -2,7 +2,21 @@ require 'test_helper'
 
 class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
 
-  MockModel = Class.new
+  MockModel = Class.new do
+    class MockConnection
+      def quote_table_name_for_assignment(table, attr)
+        "`#{table}`.`#{attr}`"
+      end
+    end
+
+    def self.connection
+      MockConnection.new
+    end
+
+    def self.table_name
+      'mock_models'
+    end
+  end
 
   def model_instance
     @model_instance ||= MockModel.new
@@ -27,27 +41,27 @@ class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
 
 
   def test_with_attribute
-    MockModel.expects(:where).with("email_mask & :mask = :mask", mask: 1)
+    MockModel.expects(:where).with("`mock_models`.`email_mask` & :mask = :mask", mask: 1)
     subject.with_emails(:send_weekly_email)
   end
 
   def test_with_attributes_array
-    MockModel.expects(:where).with("email_mask & :mask = :mask", mask: 6)
+    MockModel.expects(:where).with("`mock_models`.`email_mask` & :mask = :mask", mask: 6)
     subject.with_emails([:send_monthly_newsletter, :send_daily_spam])
   end
 
   def test_with_attributes
-    MockModel.expects(:where).with("email_mask & :mask = :mask", mask: 6)
+    MockModel.expects(:where).with("`mock_models`.`email_mask` & :mask = :mask", mask: 6)
     subject.with_emails(:send_monthly_newsletter, :send_daily_spam)
   end
 
   def test_without_attribute
-    MockModel.expects(:where).with("email_mask & :mask = 0 OR email_mask IS NULL", mask: 2)
+    MockModel.expects(:where).with("`mock_models`.`email_mask` & :mask = 0 OR `mock_models`.`email_mask` IS NULL", mask: 2)
     subject.without_emails(:send_monthly_newsletter)
   end
 
   def test_with_any_attribute
-    MockModel.expects(:where).with("email_mask & :mask <> 0", mask: 3)
+    MockModel.expects(:where).with("`mock_models`.`email_mask` & :mask <> 0", mask: 3)
     subject.with_any_emails([:send_weekly_email, :send_monthly_newsletter])
   end
 end

--- a/test/bitmasker/bitmask_scope_test.rb
+++ b/test/bitmasker/bitmask_scope_test.rb
@@ -11,11 +11,9 @@ class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
   def setup
     @klass = Bitmasker::BitmaskScope.make(
       MockModel, 'email_mask', 'emails',
-      {
-        send_weekly_email:        0b0001,
-        send_monthly_newsletter:  0b0010,
-        send_daily_spam:          0b0100,
-      }
+      send_weekly_email:        0b0001,
+      send_monthly_newsletter:  0b0010,
+      send_daily_spam:          0b0100,
     )
   end
 

--- a/test/bitmasker/bitmask_scope_test.rb
+++ b/test/bitmasker/bitmask_scope_test.rb
@@ -11,9 +11,11 @@ class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
   def setup
     @klass = Bitmasker::BitmaskScope.make(
       MockModel, 'email_mask', 'emails',
-      send_weekly_email:        0b0001,
-      send_monthly_newsletter:  0b0010,
-      send_daily_spam:          0b0100,
+      {
+        send_weekly_email:        0b0001,
+        send_monthly_newsletter:  0b0010,
+        send_daily_spam:          0b0100,
+      }
     )
   end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -133,6 +133,17 @@ class BitmaskAttributesTest < MiniTest::Unit::TestCase
     assert !mock.with_default
   end
 
+  def test_has_methods
+    mock = IntegrationModel.new
+    mock.dummy = ["does_stuff"]
+    assert mock.has_dummy?("does_stuff")
+    assert !mock.has_dummy?("with_default")
+    assert mock.has_any_dummy?("does_stuff", "with_default")
+
+    bitmask = IntegrationModel.dummy_mask("does_stuff")
+    assert bitmask.to_i == mock.dummy.bitmask.to_i
+  end
+
   # not throwing exception because you can't run migrations when it does
   # def test_raises_without_field
   #   assert_raise ArgumentError do

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -99,10 +99,10 @@ class BitmaskAttributesTest < MiniTest::Unit::TestCase
 
   def test_array_assignment
     mock = IntegrationModel.new
-    mock.dummy = ['does_stuff']
+    mock.dummy = ["does_stuff"]
     assert mock.does_stuff
     assert !mock.with_default
-    mock.dummy = ['does_stuff', 'with_default'] # should accept strings
+    mock.dummy = ["does_stuff", "with_default"] # should accept strings
     assert mock.does_stuff
     assert mock.with_default
   end
@@ -119,7 +119,7 @@ class BitmaskAttributesTest < MiniTest::Unit::TestCase
 
   def test_empty_array_assignment
     mock = IntegrationModel.new
-    mock.dummy = ['does_stuff']
+    mock.dummy = ["does_stuff"]
     assert mock.does_stuff
     mock.dummy = []
     assert !mock.does_stuff
@@ -128,7 +128,7 @@ class BitmaskAttributesTest < MiniTest::Unit::TestCase
 
   def test_array_assignment_with_empty_strings
     mock = IntegrationModel.new
-    mock.dummy = ['', 'does_stuff']
+    mock.dummy = ["", "does_stuff"]
     assert mock.does_stuff
     assert !mock.with_default
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 
-class MockModel
+class IntegrationModel
 
   attr_accessor :dummy_mask
   attr_accessor :another_dummy_mask
+  attr_accessor :something_mask
+
   extend Bitmasker::Model
 
   def []=(sym, value)
@@ -38,13 +40,16 @@ class MockModel
     config.accessible
   end
 
+  has_bitmask_attributes :something, "with_prefix_" do |config|
+    config.attribute :is_cool, 1 << 0
+  end
 end
 
 
 class BitmaskAttributesTest < MiniTest::Unit::TestCase
 
   def test_does_stuff_attribute
-    mock = MockModel.new
+    mock = IntegrationModel.new
     assert mock.dummy
     assert !mock.does_stuff?
     mock.does_stuff = true
@@ -52,53 +57,87 @@ class BitmaskAttributesTest < MiniTest::Unit::TestCase
   end
 
   def test_default
-    mock = MockModel.new
+    mock = IntegrationModel.new
     assert mock.with_default?, "should have a default: mock.dummy_mask is #{ mock.dummy_mask.inspect } mock.dummy is #{ mock.dummy.inspect }"
     mock.with_default = false
     assert !mock.with_default?, 'setting method after default failed'
   end
 
   def test_predicate_without_?
-    mock = MockModel.new
+    mock = IntegrationModel.new
     mock.does_stuff = true
     assert mock.does_stuff
   end
 
   def test_accessible
-    mock = MockModel.new
+    mock = IntegrationModel.new
     assert_equal [:an_accessible_attribute], mock.accessible_attrs
   end
 
+  def test_prefix_accessors
+    model = IntegrationModel.new
+    assert !model.respond_to?(:is_cool)
+    assert !model.respond_to?(:is_cool?)
+    assert !model.respond_to?(:is_cool=)
+    assert !model.respond_to?(:is_cool_was)
 
-#  def test_array_assignment
-#    mock = MockModel.new
-#    mock.dummy = ['does_stuff']
-#    assert mock.does_stuff
-#    assert !mock.with_default
-#    mock.dummy = ['does_stuff', 'with_default'] # should accept strings
-#    assert mock.does_stuff
-#    assert mock.with_default
-#  end
+    assert model.respond_to?(:with_prefix_is_cool)
+    assert model.respond_to?(:with_prefix_is_cool?)
+    assert model.respond_to?(:with_prefix_is_cool=)
+    assert model.respond_to?(:with_prefix_is_cool_was)
+  end
 
-#  def test_empty_array_assignment
-#    mock = MockModel.new
-#    mock.dummy = []
-#    assert !mock.does_stuff
-#    assert !mock.with_default
-#  end
+  def test_assignment_with_push
+    model = IntegrationModel.new
 
-#  def test_array_assignment_with_empty_strings
-#    mock = MockModel.new
-#    mock.dummy = ['', 'does_stuff']
-#    assert mock.does_stuff
-#    assert !mock.with_default
-#  end
+    assert !model.with_prefix_is_cool?
+
+    model.something << :is_cool
+
+    assert model.with_prefix_is_cool?
+  end
+
+  def test_array_assignment
+    mock = IntegrationModel.new
+    mock.dummy = ['does_stuff']
+    assert mock.does_stuff
+    assert !mock.with_default
+    mock.dummy = ['does_stuff', 'with_default'] # should accept strings
+    assert mock.does_stuff
+    assert mock.with_default
+  end
+
+  def test_array_assignment_with_symbols
+    mock = IntegrationModel.new
+    mock.dummy = [:does_stuff]
+    assert mock.does_stuff
+    assert !mock.with_default
+    mock.dummy = [:does_stuff, :with_default] # should accept strings
+    assert mock.does_stuff
+    assert mock.with_default
+  end
+
+  def test_empty_array_assignment
+    mock = IntegrationModel.new
+    mock.dummy = ['does_stuff']
+    assert mock.does_stuff
+    mock.dummy = []
+    assert !mock.does_stuff
+    assert !mock.with_default
+  end
+
+  def test_array_assignment_with_empty_strings
+    mock = IntegrationModel.new
+    mock.dummy = ['', 'does_stuff']
+    assert mock.does_stuff
+    assert !mock.with_default
+  end
 
   # not throwing exception because you can't run migrations when it does
   # def test_raises_without_field
   #   assert_raise ArgumentError do
   #     eval '
-  #     class MockModel
+  #     class IntegrationModel
   #       extend ::BitmaskAttributes
   #
   #       has_bitmask_attributes :without_field do |config|


### PR DESCRIPTION
- Adds prefix methods for model accessors
- Implements array setters
- Implements << setters
  
  ```
  class MyModel
    extend Bitmasker::Model
  
  has_bitmask_attributes :roles, 'has_role_' do |config|
    config.attribute :admin, 1 << 0
    config.attribute :manager, 1 << 1
   end
  end
  
  my_model.roles << :admin
  my_model.roles = [:admin, :manager]
  
  my_model.has_role_admin? # true
  ```
