### PR TITLE
value_to_boolean is gone in rails 4.2

### DIFF
--- a/lib/bitmasker/model.rb
+++ b/lib/bitmasker/model.rb
@@ -8,8 +8,8 @@ module Bitmasker
     end
 
     def value_to_boolean(value)
-      if defined? ::ActiveRecord::ConnectionAdapters::Column
-        ::ActiveRecord::ConnectionAdapters::Column.value_to_boolean(value)
+      if defined? ::ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES
+        ::ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include? value
       else
         ['1', 1, 't', 'true', true].include? value
       end


### PR DESCRIPTION
`value_to_boolean` is totally gone now in rails 4.2. I believe it's been deprecated for a while too. this uses the TRUE_VALUES out of `Column`.