### PR TITLE
Fix AmbiguousColumn errors by explicitly naming table in SQL queries

### DIFF
--- a/lib/bitmasker/bitmask_scope.rb
+++ b/lib/bitmasker/bitmask_scope.rb
@@ -7,6 +7,7 @@ module Bitmasker
 
     class_attribute :model_class
     class_attribute :field_name
+    class_attribute :table_name
     class_attribute :mask_name
     class_attribute :bitmask_attributes
 
@@ -20,6 +21,7 @@ module Bitmasker
       end
 
       klass.model_class = model_class
+      klass.table_name = model_class.table_name
       klass.field_name = field_name
       klass.mask_name = mask_name
       klass.bitmask_attributes = bitmask_attributes.stringify_keys
@@ -34,17 +36,17 @@ module Bitmasker
     # REVIEW: This (the unused _ attribute) tells me I have the design wrong
     def with_attribute(_, *attributes)
       # TODO: Test lots of databases
-      bitmask_query attributes, "#{field_name} & :mask = :mask"
+      bitmask_query attributes, "#{table_name}.#{field_name} & :mask = :mask"
     end
 
     def with_any_attribute(_, *attributes)
       # TODO: Test lots of databases
-      bitmask_query attributes, "#{field_name} & :mask <> 0"
+      bitmask_query attributes, "#{table_name}.#{field_name} & :mask <> 0"
     end
 
     def without_attribute(_, *attributes)
       # TODO: Test lots of databases
-      bitmask_query attributes, "#{field_name} & :mask = 0 OR #{field_name} IS NULL"
+      bitmask_query attributes, "#{table_name}.#{field_name} & :mask = 0 OR #{table_name}.#{field_name} IS NULL"
     end
 
     private

--- a/test/bitmasker/bitmask_attributes_test.rb
+++ b/test/bitmasker/bitmask_attributes_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class Bitmasker::BitmaskAttributesTest < MiniTest::Unit::TestCase
 
   MockModel = Class.new do
+    def self.table_name
+      "mock_models"
+    end
+
     def self.value_to_boolean(value)
       !!value
     end

--- a/test/bitmasker/bitmask_scope_test.rb
+++ b/test/bitmasker/bitmask_scope_test.rb
@@ -2,7 +2,11 @@ require 'test_helper'
 
 class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
 
-  MockModel = Class.new
+  MockModel = Class.new do
+    def self.table_name
+      "mock_models"
+    end
+  end
 
   def model_instance
     @model_instance ||= MockModel.new
@@ -27,27 +31,27 @@ class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
 
 
   def test_with_attribute
-    MockModel.expects(:where).with("email_mask & :mask = :mask", mask: 1)
+    MockModel.expects(:where).with("mock_models.email_mask & :mask = :mask", mask: 1)
     subject.with_emails(:send_weekly_email)
   end
 
   def test_with_attributes_array
-    MockModel.expects(:where).with("email_mask & :mask = :mask", mask: 6)
+    MockModel.expects(:where).with("mock_models.email_mask & :mask = :mask", mask: 6)
     subject.with_emails([:send_monthly_newsletter, :send_daily_spam])
   end
 
   def test_with_attributes
-    MockModel.expects(:where).with("email_mask & :mask = :mask", mask: 6)
+    MockModel.expects(:where).with("mock_models.email_mask & :mask = :mask", mask: 6)
     subject.with_emails(:send_monthly_newsletter, :send_daily_spam)
   end
 
   def test_without_attribute
-    MockModel.expects(:where).with("email_mask & :mask = 0 OR email_mask IS NULL", mask: 2)
+    MockModel.expects(:where).with("mock_models.email_mask & :mask = 0 OR mock_models.email_mask IS NULL", mask: 2)
     subject.without_emails(:send_monthly_newsletter)
   end
 
   def test_with_any_attribute
-    MockModel.expects(:where).with("email_mask & :mask <> 0", mask: 3)
+    MockModel.expects(:where).with("mock_models.email_mask & :mask <> 0", mask: 3)
     subject.with_any_emails([:send_weekly_email, :send_monthly_newsletter])
   end
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -6,6 +6,10 @@ class MockModel
   attr_accessor :another_dummy_mask
   extend Bitmasker::Model
 
+  def self.table_name
+    "mock_models"
+  end
+
   def []=(sym, value)
     send "#{ sym }=", value
   end


### PR DESCRIPTION
With more complex queries, scopes can break with `AmbiguousColumn` errors. This explicitly adds the table name of the column being searched into the query to prevent the issue.