### PR TITLE
Allow analysis of bitmask from static perspective

### DIFF
--- a/lib/bitmasker/bitmask_scope.rb
+++ b/lib/bitmasker/bitmask_scope.rb
@@ -29,8 +29,8 @@ module Bitmasker
       klass
     end
 
-    def bitmask
-      Bitmask.new(bitmask_attributes, 0)
+    def bitmask(mask = 0)
+      Bitmask.new(bitmask_attributes, mask)
     end
 
     # REVIEW: This (the unused _ attribute) tells me I have the design wrong

--- a/test/bitmasker/bitmask_scope_test.rb
+++ b/test/bitmasker/bitmask_scope_test.rb
@@ -55,6 +55,10 @@ class Bitmasker::BitmaskScopeTest < MiniTest::Unit::TestCase
     subject.with_any_emails([:send_weekly_email, :send_monthly_newsletter])
   end
 
+  def test_bitmask_with_mask_code
+    assert_equal ["send_monthly_newsletter", "send_daily_spam"], subject.bitmask(6).to_a
+  end
+
   def test_with_unmatching_attribute
     MockModel.expects(:where).with("1 = 0")
     subject.with_emails(:omg_not_an_attribute)


### PR DESCRIPTION
I haven't found another way yet to check what the value of a bitmask means for a given scope. This would allow us to get the bitmask for a specific mask value without changing the default value. Now you can say

```ruby
Dummy.dummy_scope.bitmask(68)
```

And you would get back a bitmask object you can convert to an array or whatever you need to do.